### PR TITLE
Update to mjlab 1.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ deploy/robots/r1/build
 deploy/robots/a2/build
 src/assets/motions/g1/dance1_subject2.npz
 simulate/build
+__pycache__

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,7 @@ from setuptools import setup, find_packages
 
 # Minimum dependencies required prior to installation
 INSTALL_REQUIRES = [
-    "mjlab==1.2.0",
-    "mujoco-warp==3.5.0",
+    "mjlab==1.3.0"
 ]
 
 # Installation operation

--- a/src/assets/robots/_utils.py
+++ b/src/assets/robots/_utils.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+from typing import Any, Dict
+
+
+def update_assets(
+  assets: Dict[str, Any],
+  path: str | Path,
+  meshdir: str | None = None,
+  glob: str = "*",
+  recursive: bool = False,
+):
+  """Update assets dictionary with files from a directory.
+
+  This function reads files from a directory and adds them to an assets dictionary,
+  with keys formatted to include the meshdir prefix when specified.
+
+  Args:
+    assets: Dictionary to update with file contents. Keys are asset paths, values are
+      file contents as bytes.
+    path: Path to directory containing asset files.
+    meshdir: Optional mesh directory prefix, typically `spec.meshdir`. If provided,
+      will be prepended to asset keys (e.g., "mesh.obj" becomes "custom_dir/mesh.obj").
+    glob: Glob pattern for file matching. Defaults to "*" (all files).
+    recursive: If True, recursively search subdirectories.
+  """
+  for f in Path(path).glob(glob):
+    if f.is_file():
+      asset_key = f"{meshdir}/{f.name}" if meshdir else f.name
+      assets[asset_key] = f.read_bytes()
+    elif f.is_dir() and recursive:
+      update_assets(assets, f, meshdir, glob, recursive)

--- a/src/assets/robots/unitree_a2/a2_constants.py
+++ b/src/assets/robots/unitree_a2/a2_constants.py
@@ -8,7 +8,7 @@ from src import SRC_PATH
 from mjlab.actuator import BuiltinPositionActuatorCfg
 from mjlab.entity import EntityArticulationInfoCfg, EntityCfg
 from mjlab.utils.actuator import ElectricActuator, reflected_inertia
-from mjlab.utils.os import update_assets
+from src.assets.robots._utils import update_assets
 from mjlab.utils.spec_config import CollisionCfg
 
 ##

--- a/src/assets/robots/unitree_as2/as2_constants.py
+++ b/src/assets/robots/unitree_as2/as2_constants.py
@@ -8,7 +8,7 @@ from src import SRC_PATH
 from mjlab.actuator import BuiltinPositionActuatorCfg
 from mjlab.entity import EntityArticulationInfoCfg, EntityCfg
 from mjlab.utils.actuator import ElectricActuator, reflected_inertia
-from mjlab.utils.os import update_assets
+from src.assets.robots._utils import update_assets
 from mjlab.utils.spec_config import CollisionCfg
 
 ##

--- a/src/assets/robots/unitree_g1/g1_23dof_constants.py
+++ b/src/assets/robots/unitree_g1/g1_23dof_constants.py
@@ -11,7 +11,7 @@ from mjlab.utils.actuator import (
   ElectricActuator,
   reflected_inertia_from_two_stage_planetary,
 )
-from mjlab.utils.os import update_assets
+from src.assets.robots._utils import update_assets
 from mjlab.utils.spec_config import CollisionCfg
 
 ##

--- a/src/assets/robots/unitree_g1/g1_constants.py
+++ b/src/assets/robots/unitree_g1/g1_constants.py
@@ -11,7 +11,7 @@ from mjlab.utils.actuator import (
   ElectricActuator,
   reflected_inertia_from_two_stage_planetary,
 )
-from mjlab.utils.os import update_assets
+from src.assets.robots._utils import update_assets
 from mjlab.utils.spec_config import CollisionCfg
 
 ##

--- a/src/assets/robots/unitree_go2/go2_constants.py
+++ b/src/assets/robots/unitree_go2/go2_constants.py
@@ -8,7 +8,7 @@ from src import SRC_PATH
 from mjlab.actuator import BuiltinPositionActuatorCfg
 from mjlab.entity import EntityArticulationInfoCfg, EntityCfg
 from mjlab.utils.actuator import ElectricActuator, reflected_inertia
-from mjlab.utils.os import update_assets
+from src.assets.robots._utils import update_assets
 from mjlab.utils.spec_config import CollisionCfg
 
 ##

--- a/src/assets/robots/unitree_h1_2/h1_2_constants.py
+++ b/src/assets/robots/unitree_h1_2/h1_2_constants.py
@@ -7,7 +7,7 @@ import mujoco
 from src import SRC_PATH
 from mjlab.actuator import BuiltinPositionActuatorCfg
 from mjlab.entity import EntityArticulationInfoCfg, EntityCfg
-from mjlab.utils.os import update_assets
+from src.assets.robots._utils import update_assets
 from mjlab.utils.spec_config import CollisionCfg
 
 ##

--- a/src/assets/robots/unitree_h2/h2_constants.py
+++ b/src/assets/robots/unitree_h2/h2_constants.py
@@ -7,7 +7,7 @@ import mujoco
 from src import SRC_PATH
 from mjlab.actuator import BuiltinPositionActuatorCfg
 from mjlab.entity import EntityArticulationInfoCfg, EntityCfg
-from mjlab.utils.os import update_assets
+from src.assets.robots._utils import update_assets
 from mjlab.utils.spec_config import CollisionCfg
 
 ##

--- a/src/assets/robots/unitree_r1/r1_constants.py
+++ b/src/assets/robots/unitree_r1/r1_constants.py
@@ -7,7 +7,7 @@ import mujoco
 from src import SRC_PATH
 from mjlab.actuator import BuiltinPositionActuatorCfg
 from mjlab.entity import EntityArticulationInfoCfg, EntityCfg
-from mjlab.utils.os import update_assets
+from src.assets.robots._utils import update_assets
 from mjlab.utils.spec_config import CollisionCfg
 
 ##


### PR DESCRIPTION
Bumps dependency from mjlab 1.2.0 (dropping mujoco-warp) to 1.3.0, adds a local _utils.py with update_assets since it was removed from mjlab.utils.os, and updates all robot constants files to import from the new location.