### PR TITLE
Update the minimum dependency list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,10 @@ from setuptools import setup, find_packages
 # Minimum dependencies required prior to installation
 INSTALL_REQUIRES = [
     "mjlab==1.2.0",
+    "mujoco==3.5.0",
     "mujoco-warp==3.5.0",
+    "scipy>=1.15.0",  # for supporting Python >= 3.10
+    "warp-lang==1.12.0",
 ]
 
 # Installation operation


### PR DESCRIPTION
This PR resolves #47. As the latest releases of some packages change API, this repository needs to specify the version of dependencies.

Although we can apply update throughout this repository, this PR proposed the minimum update of `setup.py` respecting the original settings, i.e. `mjlab==1.2.0` and `mujoco-warp==3.5.0`.

We are also glad if you leave some message for #38 to tell us your maintenance policy of this repository.

Thanks!