### PR TITLE
Add keyboard control (--keyboard), deploy.yaml exporter, and update deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,39 @@ Connect your PC to the robot via Ethernet. Configure the network as:
 
 Use `ifconfig` to determine the Ethernet device name for deployment.
 
-#### 4.4 Compilation
+#### 4.4 Export the Deployment Config (`deploy.yaml`)
+
+Every deployed policy needs a `deploy.yaml` that tells the C++ controller the PD
+gains, default joint pose, action scale/offset and observation layout. These
+values **must match the policy you trained** — the joint target is
+`action * scale + offset`, so a mismatched `offset` / `default_joint_pos`
+(e.g. one copied from a different motion) will command the robot to the wrong
+pose and can damage it. Instead of hand-copying the file, generate it directly
+from the trained task:
+
+```bash
+python scripts/export_deploy.py \
+  --task Unitree-G1-Tracking-No-State-Estimation \
+  --motion-file deploy/robots/g1/config/policy/mimic/dance_train/params/dance1_subject2.npz \
+  --output deploy/robots/g1/config/policy/mimic/dance_train/params/deploy.yaml \
+  --onnx deploy/robots/g1/config/policy/mimic/dance_train/exported/policy.onnx
+```
+
+**Arguments**：
+- `--task`: the registered task id used for deployment (the `-No-State-Estimation`
+  variant for tracking — its 154-dim observation matches the deployed policy).
+- `--motion-file`: the motion `.npz` the policy was trained on (used to build the env).
+- `--output`: where to write `deploy.yaml` (the policy's `params/` folder).
+- `--onnx` (optional): the exported policy. When given, the exporter validates that
+  the observation dimension matches the ONNX input and aborts on mismatch, catching
+  a wrong task variant or a stale config before it reaches the robot.
+
+> [!NOTE]
+> The exporter reads the **current** task config, which must match the config used
+> at training time. If you change the task config or robot asset after training,
+> re-export from a state matching that run.
+
+#### 4.5 Compilation
 
 Example: Unitree G1 velocity control.
 Place `policy.onnx` and `policy.onnx.data` into: `deploy/robots/g1/config/policy/velocity/v0/exported`.
@@ -176,9 +208,9 @@ mkdir build && cd build
 cmake .. && make
 ```
 
-#### 4.5 Deployment
+#### 4.6 Deployment
 
-## 4.5.1 Simulation Deployment
+## 4.6.1 Simulation Deployment
 
 Before deploying on the real robot, it is recommended to perform simulation deployment using [unitree_mujoco](https://github.com/unitreerobotics/unitree_mujoco)
 to prevent abnormal behaviors on the physical robot. This framework has already integrated it.
@@ -206,7 +238,30 @@ cd deploy/robots/g1/build
 ./g1_ctrl --network=lo
 ```
 
-## 4.5.2 Real-Robot Deployment
+**Keyboard control (no gamepad):** add the `--keyboard` flag to drive the robot from
+the keyboard instead of a gamepad. The keyboard acts as a virtual joystick, so both
+the velocity commands and the FSM transitions work exactly as with a real controller.
+
+```bash
+cd deploy/robots/g1/build
+./g1_ctrl --network=lo --keyboard
+```
+
+| Key         | Action                                   |
+|-------------|------------------------------------------|
+| `2`         | FixStand (stand up)                      |
+| `3`         | Velocity (start the walking policy)      |
+| `4`         | Mimic (dance)                            |
+| `1`         | Passive (damping / soft stop)            |
+| `w` / `s`   | move forward / backward                  |
+| `a` / `d`   | strafe left / right                      |
+| `q` / `e`   | turn left / right                        |
+| `space`     | stop (zero velocity)                     |
+
+Typical flow: press `2` to stand, then `3` to start walking, then use `w/a/s/d/q/e`.
+Velocity is *latched* (each tap adjusts the setpoint by 0.2), so press `space` to stop.
+
+## 4.6.2 Real-Robot Deployment
 
 Launch the control program on the real robot:
 

--- a/deploy/include/FSM/FSMState.h
+++ b/deploy/include/FSM/FSMState.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <algorithm>
+
 #include "Types.h"
 #include "param.h"
 #include "FSM/BaseState.h"
@@ -57,6 +59,7 @@ public:
     {
         lowstate->update();
         if(keyboard) keyboard->update();
+        if(use_keyboard && keyboard) keyboard_control();
     }
 
     void post_run()
@@ -67,4 +70,76 @@ public:
     static std::unique_ptr<LowCmd_t> lowcmd;
     static std::shared_ptr<LowState_t> lowstate;
     static std::shared_ptr<Keyboard> keyboard;
+
+    // Enabled by the `--keyboard` flag. When true, the keyboard drives a
+    // virtual joystick so the robot can be controlled without a gamepad.
+    inline static bool use_keyboard = false;
+
+    /**
+     * @brief Translate keyboard input into `lowstate->joystick`, so that both the
+     * velocity commands and the FSM transitions (which all read the joystick)
+     * behave exactly as if a real gamepad were connected.
+     *
+     * Controls:
+     *   Locomotion (latched velocity setpoints, tap to adjust):
+     *     w / s : forward / backward       (vx)
+     *     a / d : strafe left / right      (vy)
+     *     q / e : turn left / right        (yaw)
+     *     space / x : stop (zero velocity)
+     *   Mode switches (single press, emulate the gamepad combos):
+     *     1 : Passive   (LT + B)   -- damping / soft stop
+     *     2 : FixStand  (LT + up)  -- stand up
+     *     3 : Velocity  (RT + A)   -- start the walking policy
+     *     4 : Mimic     (RB + A)   -- dance
+     */
+    void keyboard_control()
+    {
+        auto & js = lowstate->joystick;
+
+        // Keyboard input is digital: disable the analog smoothing so a key press
+        // maps to the axis/trigger value immediately (and releases cleanly).
+        js.lx.smooth = js.ly.smooth = js.rx.smooth = 1.f;
+        js.LT.smooth = js.RT.smooth = 1.f;
+
+        // Latched velocity setpoints, in joystick-axis units [-1, 1].
+        static float sp_ly = 0.f;  // + forward
+        static float sp_lx = 0.f;  // + strafe right
+        static float sp_rx = 0.f;  // + turn right
+        constexpr float kStep = 0.2f;
+
+        const std::string k = keyboard->key();
+
+        // React only on the key-down edge (avoids terminal auto-repeat quirks).
+        if(keyboard->on_pressed)
+        {
+            bool cmd_changed = true;
+            if(k == "w")      sp_ly = std::clamp(sp_ly + kStep, -1.f, 1.f);
+            else if(k == "s") sp_ly = std::clamp(sp_ly - kStep, -1.f, 1.f);
+            else if(k == "d") sp_lx = std::clamp(sp_lx + kStep, -1.f, 1.f);
+            else if(k == "a") sp_lx = std::clamp(sp_lx - kStep, -1.f, 1.f);
+            else if(k == "e") sp_rx = std::clamp(sp_rx + kStep, -1.f, 1.f);
+            else if(k == "q") sp_rx = std::clamp(sp_rx - kStep, -1.f, 1.f);
+            else if(k == " " || k == "x") { sp_ly = sp_lx = sp_rx = 0.f; }
+            else cmd_changed = false;
+
+            if(cmd_changed)
+            {
+                // Observation mapping: vx = ly, vy = -lx, wz = -rx.
+                spdlog::info("[keyboard] cmd  vx={:+.2f}  vy={:+.2f}  wz={:+.2f}",
+                             sp_ly, -sp_lx, -sp_rx);
+            }
+
+            // FSM mode switches: press the corresponding virtual button combo for
+            // this single frame, and reset the velocity for a safe hand-off.
+            if(k == "1")      { js.LT(1.f); js.B(1);  sp_ly = sp_lx = sp_rx = 0.f; }
+            else if(k == "2") { js.LT(1.f); js.up(1); sp_ly = sp_lx = sp_rx = 0.f; }
+            else if(k == "3") { js.RT(1.f); js.A(1);  sp_ly = sp_lx = sp_rx = 0.f; }
+            else if(k == "4") { js.RB(1);   js.A(1);  sp_ly = sp_lx = sp_rx = 0.f; }
+        }
+
+        // Drive the velocity axes continuously from the latched setpoints.
+        js.lx(sp_lx);
+        js.ly(sp_ly);
+        js.rx(sp_rx);
+    }
 };

--- a/deploy/include/param.h
+++ b/deploy/include/param.h
@@ -130,6 +130,7 @@ inline po::variables_map helper(int argc, char** argv)
         ("version,v", "show version")
         ("log", "record log file")
         ("network,n", po::value<std::string>()->default_value(""), "dds network interface")
+        ("keyboard,k", "use the keyboard as a virtual joystick (no gamepad needed)")
         ;
 
     po::variables_map vm;

--- a/deploy/robots/g1/main.cpp
+++ b/deploy/robots/g1/main.cpp
@@ -30,6 +30,9 @@ int main(int argc, char** argv)
     // Load parameters
     auto vm = param::helper(argc, argv);
 
+    // Use the keyboard as a virtual joystick when `--keyboard` is given.
+    FSMState::use_keyboard = vm.count("keyboard") > 0;
+
     std::cout << " --- Unitree Robotics --- \n";
     std::cout << "     G1-29dof Controller \n";
 
@@ -48,9 +51,19 @@ int main(int argc, char** argv)
     auto fsm = std::make_unique<CtrlFSM>(param::config["FSM"]);
     fsm->start();
 
-    std::cout << "Press [L2 + Up] to enter FixStand mode.\n";
-    std::cout << "And then press [R2 + A] to start controlling the robot.\n";
-    std::cout << "And then press [R1 + A/B/Y/X] to control the robot dance.\n";
+    if(FSMState::use_keyboard)
+    {
+        std::cout << "\n--- Keyboard control enabled (virtual joystick) ---\n";
+        std::cout << "  Mode:  [2] FixStand   [3] Velocity(walk)   [4] Mimic(dance)   [1] Passive(stop)\n";
+        std::cout << "  Move:  [w/s] forward/back   [a/d] strafe   [q/e] turn   [space] stop\n";
+        std::cout << "  Flow:  press 2 to stand, then 3 to walk, then use w/a/s/d/q/e.\n\n";
+    }
+    else
+    {
+        std::cout << "Press [L2 + Up] to enter FixStand mode.\n";
+        std::cout << "And then press [R2 + A] to start controlling the robot.\n";
+        std::cout << "And then press [R1 + A/B/Y/X] to control the robot dance.\n";
+    }
 
     while (true)
     {

--- a/scripts/export_deploy.py
+++ b/scripts/export_deploy.py
@@ -1,0 +1,218 @@
+"""Auto-generate ``deploy.yaml`` from a trained tracking (mimic) task.
+
+Motivation (see unitreerobotics/unitree_rl_mjlab#23): deploying a new motion
+policy currently requires hand-copying ``deploy.yaml`` from another run. A
+mismatched ``default_joint_pos`` / ``offset`` (the absolute joint target is
+``action * scale + offset``) commands the robot to the wrong pose and can
+damage the G1. This script derives every field directly from the instantiated
+environment so the deployed config always matches the trained policy.
+
+The PD gains, default joint pose, action scale/offset and observation layout
+are read from the *current* task config (which must match the config used at
+training time). Cross-check the exported observation dimension against the
+policy ONNX input with ``--onnx``.
+
+Example:
+  python scripts/export_deploy.py \
+    --task Unitree-G1-Tracking-No-State-Estimation \
+    --motion-file deploy/robots/g1/config/policy/mimic/dance_train/params/dance1_subject2.npz \
+    --output deploy/robots/g1/config/policy/mimic/dance_train/params/deploy.yaml \
+    --onnx deploy/robots/g1/config/policy/mimic/dance_train/exported/policy.onnx
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+import tyro
+
+# Deployment-side observation naming. The C++ runtime identifies each observation
+# by these names, which differ from the env's internal term names. Maps
+# env-actor-term-name -> (deploy_name, deploy_params).
+TRACKING_OBS_MAP: dict[str, tuple[str, dict]] = {
+  "command": ("motion_command", {"command_name": "motion"}),
+  "motion_anchor_ori_b": ("motion_anchor_ori_b", {"command_name": "motion"}),
+  "base_ang_vel": ("base_ang_vel", {}),
+  "joint_pos": ("joint_pos_rel", {}),
+  "joint_vel": ("joint_vel_rel", {}),
+  "actions": ("last_action", {}),
+}
+
+
+@dataclass(frozen=True)
+class ExportConfig:
+  task: str
+  """Registered task id (must be the *deploy* variant, e.g. the No-State-Estimation one)."""
+  motion_file: str
+  """Path to the motion .npz the policy was trained on (needed to build the env)."""
+  output: str
+  """Where to write deploy.yaml."""
+  onnx: str | None = None
+  """Optional: policy .onnx to validate the observation dimension against."""
+  device: str = "cpu"
+
+
+def _fmt_num(v) -> str:
+  """Format a number, keeping floats float-typed in YAML (e.g. ``1`` -> ``1.0``)."""
+  if isinstance(v, float):
+    s = f"{v:.6g}"
+    if "." not in s and "e" not in s and "n" not in s:  # not nan/inf either
+      s += ".0"
+    return s
+  return str(v)
+
+
+def _fmt_list(values, per_line: int = 15, indent: int = 12) -> str:
+  """Format a numeric list as inline YAML, wrapping every ``per_line`` items."""
+  pad = " " * indent
+  parts = [_fmt_num(v) for v in values]
+  lines = []
+  for i in range(0, len(parts), per_line):
+    lines.append(", ".join(parts[i : i + per_line]))
+  body = (",\n" + pad).join(lines)
+  return f"[{body}]"
+
+
+def build_deploy_dict(cfg: ExportConfig):
+  import mjlab.tasks  # noqa: F401
+  import src.tasks  # noqa: F401
+  from mjlab.envs import ManagerBasedRlEnv
+  from mjlab.tasks.registry import load_env_cfg
+
+  env_cfg = load_env_cfg(cfg.task, play=True)
+
+  motion_path = Path(cfg.motion_file)
+  if not motion_path.exists():
+    raise FileNotFoundError(f"Motion file not found: {motion_path}")
+  env_cfg.commands["motion"].motion_file = str(motion_path)
+  env_cfg.scene.num_envs = 1
+
+  env = ManagerBasedRlEnv(cfg=env_cfg, device=cfg.device)
+  u = env.unwrapped
+  robot = u.scene["robot"]
+  joint_names = list(robot.joint_names)
+  n = len(joint_names)
+
+  # PD gains from the compiled MuJoCo model (position actuators):
+  #   kp = actuator_gainprm[0], kd = -actuator_biasprm[2].
+  mjm = u.sim.mj_model
+  name2kp: dict[str, float] = {}
+  name2kd: dict[str, float] = {}
+  for i in range(mjm.nu):
+    jname = mjm.joint(int(mjm.actuator_trnid[i, 0])).name.split("/")[-1]
+    name2kp[jname] = float(mjm.actuator_gainprm[i][0])
+    name2kd[jname] = float(-mjm.actuator_biasprm[i][2])
+  stiffness = [round(name2kp[j], 4) for j in joint_names]
+  damping = [round(name2kd[j], 4) for j in joint_names]
+
+  default_joint_pos = [
+    round(float(x), 6) for x in robot.data.default_joint_pos[0].tolist()
+  ]
+
+  action_term = u.action_manager.get_term("joint_pos")
+  scale_t = action_term.scale
+  offset_t = action_term.offset
+  scale = [
+    round(float(x), 6)
+    for x in (scale_t[0] if scale_t.ndim > 1 else scale_t).tolist()
+  ]
+  offset = [
+    round(float(x), 6)
+    for x in (offset_t[0] if offset_t.ndim > 1 else offset_t).tolist()
+  ]
+
+  # Observations (actor group only).
+  om = u.observation_manager
+  term_names = list(om._group_obs_term_names["actor"])
+  term_dims = [int(d[0]) for d in om._group_obs_term_dim["actor"]]
+  obs_block = []
+  total_obs = 0
+  for name, dim in zip(term_names, term_dims):
+    if name not in TRACKING_OBS_MAP:
+      raise KeyError(
+        f"Observation term '{name}' has no deploy mapping. "
+        f"Update TRACKING_OBS_MAP in {Path(__file__).name}."
+      )
+    deploy_name, params = TRACKING_OBS_MAP[name]
+    obs_block.append((deploy_name, params, dim))
+    total_obs += dim
+
+  step_dt = round(u.cfg.decimation * u.cfg.sim.mujoco.timestep, 6)
+
+  env.close()
+
+  return {
+    "joint_names": joint_names,
+    "n": n,
+    "step_dt": step_dt,
+    "stiffness": stiffness,
+    "damping": damping,
+    "default_joint_pos": default_joint_pos,
+    "scale": scale,
+    "offset": offset,
+    "obs_block": obs_block,
+    "total_obs": total_obs,
+  }
+
+
+def render_yaml(d) -> str:
+  n = d["n"]
+  lines = []
+  lines.append(f"joint_ids_map: {list(range(n))}")
+  lines.append(f"step_dt: {d['step_dt']}")
+  lines.append(f"stiffness: {_fmt_list(d['stiffness'])}")
+  lines.append(f"damping:   {_fmt_list(d['damping'])}")
+  lines.append(f"default_joint_pos: {_fmt_list(d['default_joint_pos'], per_line=n)}")
+  lines.append("commands: {}")
+  lines.append("actions:")
+  lines.append("  JointPositionAction:")
+  lines.append("    clip: null")
+  lines.append("    joint_names: [.*]")
+  lines.append(f"    scale: {_fmt_list(d['scale'])}")
+  lines.append(f"    offset: {_fmt_list(d['offset'], per_line=n)}")
+  lines.append("    joint_ids: null")
+  lines.append("observations:")
+  for deploy_name, params, dim in d["obs_block"]:
+    lines.append(f"  {deploy_name}:")
+    pstr = (
+      "{" + ", ".join(f"{k}: {v}" for k, v in params.items()) + "}" if params else "{}"
+    )
+    lines.append(f"    params: {pstr}")
+    lines.append("    clip: null")
+    lines.append(f"    scale: {_fmt_list([1.0] * dim)}")
+    lines.append("    history_length: 1")
+  return "\n".join(lines) + "\n"
+
+
+def main():
+  cfg = tyro.cli(ExportConfig)
+  d = build_deploy_dict(cfg)
+
+  print(f"[INFO] joints: {d['n']}  observation dim: {d['total_obs']}  step_dt: {d['step_dt']}")
+
+  if cfg.onnx is not None:
+    import onnx
+
+    m = onnx.load(cfg.onnx)
+    in_dim = m.graph.input[0].type.tensor_type.shape.dim[-1].dim_value
+    if in_dim != d["total_obs"]:
+      print(
+        f"[ERROR] ONNX input dim ({in_dim}) != exported observation dim "
+        f"({d['total_obs']}). Wrong task variant or stale config — aborting.",
+        file=sys.stderr,
+      )
+      sys.exit(1)
+    print(f"[INFO] ONNX input dim {in_dim} matches observation dim. OK.")
+
+  text = render_yaml(d)
+  out = Path(cfg.output)
+  out.parent.mkdir(parents=True, exist_ok=True)
+  out.write_text(text)
+  print(f"[INFO] Wrote {out}")
+
+
+if __name__ == "__main__":
+  main()

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,9 @@ from setuptools import setup, find_packages
 INSTALL_REQUIRES = [
     "mjlab==1.2.0",
     "mujoco-warp==3.5.0",
+    "warp-lang==1.12.0",
+    "mujoco==3.5.0",
+    "scipy>=1.15.0",
 ]
 
 # Installation operation

--- a/simulate/config.yaml
+++ b/simulate/config.yaml
@@ -12,7 +12,7 @@ robot_scene: "src/assets/robots/unitree_g1/xmls/scene_g1.xml"
 domain_id: 0  # Domain id
 interface: "lo" # Interface
 
-use_joystick: 1 # Simulate Unitree WirelessController using a gamepad
+use_joystick: 0 # Simulate Unitree WirelessController using a gamepad (set 0 to run without a gamepad, e.g. keyboard control via `g1_ctrl --keyboard`)
 joystick_type: "xbox" # support "xbox" and "switch" gamepad layout
 joystick_device: "/dev/input/js0" # Device path
 joystick_bits: 16 # Some game controllers may only have 8-bit accuracy


### PR DESCRIPTION
## Summary
Three changes for deployment:

**1. Keyboard control (`--keyboard`)** — run the G1 controller without a gamepad.
The keyboard maps to `lowstate->joystick`, so velocity commands and FSM
transitions work exactly as with a real controller.
`2/3/4/1` = FixStand/Velocity/Mimic/Passive · `w a s d q e` = move · `space` = stop.

**2. `deploy.yaml` exporter** — `scripts/export_deploy.py` derives every deploy
field (PD gains, default pose, action scale/offset, obs layout) from the trained
env, so the config always matches the policy. Optional `--onnx` checks the obs
dim and aborts on mismatch. Avoids hand-copying a mismatched config that can
damage the robot.
Fixes #23.

**3. Dependency update (`setup.py`)** — adds `warp-lang==1.12.0`, `mujoco==3.5.0`,
`scipy>=1.15.0` (needed by the exporter).

## Notes
- README updated for the keyboard and exporter flows.

## Testing
- Ran `--keyboard` in unitree_mujoco: stand → walk → dance + velocity OK.
- Ran the exporter; generated `deploy.yaml` matches the policy, `--onnx` check passes.
