### PR TITLE
Fix R1 MJCF: contact excludes reference bodies that do not exist

### DIFF
--- a/src/assets/robots/unitree_r1/xmls/r1.xml
+++ b/src/assets/robots/unitree_r1/xmls/r1.xml
@@ -235,8 +235,8 @@
     </body>
   </worldbody>
   <contact>
-    <exclude body1="left_elbow_link" body2="left_wrist_pitch_link"/>
-    <exclude body1="right_elbow_link" body2="right_wrist_pitch_link"/>
+    <exclude body1="left_elbow_link" body2="left_wrist_roll_link"/>
+    <exclude body1="right_elbow_link" body2="right_wrist_roll_link"/>
     <exclude body1="pelvis" body2="right_hip_roll_link"/>
     <exclude body1="pelvis" body2="left_hip_roll_link"/>
   </contact>


### PR DESCRIPTION
## Problem

`src/assets/robots/unitree_r1/xmls/r1.xml` does not compile as published.

The `<contact>` block excludes `left_wrist_pitch_link` and `right_wrist_pitch_link`, but the R1 has no wrist *pitch* bodies. The wrist DOF is `wrist_roll`, and `wrist_pitch` appears nowhere else in the file — only in these two lines. MuJoCo rejects the model outright:

```
ValueError: Error: body 'left_wrist_pitch_link' not found in bodypair 0
Element name '', id 0, line 238
```

Reproduce on a clean checkout of `main`:

```bash
python -c "import mujoco; mujoco.MjModel.from_xml_path(
  'src/assets/robots/unitree_r1/xmls/r1.xml')"
```

Anyone starting from the R1 asset hits this before they can train anything.

## Fix

Point the two excludes at the bodies that exist. `left_wrist_roll_link` and `right_wrist_roll_link` are direct children of `left_elbow_link` / `right_elbow_link`, which is the pair the excludes were evidently meant to name.

```diff
-    <exclude body1="left_elbow_link" body2="left_wrist_pitch_link"/>
-    <exclude body1="right_elbow_link" body2="right_wrist_pitch_link"/>
+    <exclude body1="left_elbow_link" body2="left_wrist_roll_link"/>
+    <exclude body1="right_elbow_link" body2="right_wrist_roll_link"/>
```

## Why rename and not delete

Deleting the two lines also compiles, and today it behaves identically: there is no `<option>`/`<flag>` block in this model, so `filterparent` is at its default (enabled) and the elbow↔wrist_roll parent-child pair is already filtered regardless of the exclude.

Renaming is preferred because it keeps the original intent explicit and stays correct if `filterparent` is ever disabled. Both bodies do carry a collidable geom (verified: 1 each), so the exclude is not vacuous — it is just currently unreachable.

## Verification

With the patch applied, on this repo's own asset directory:

```
patched upstream file COMPILES: 26 bodies, nexclude=4
```

Before: `ValueError` at line 238. After: compiles clean.

## Notes

- One file, two lines, no behaviour change on a default-flag model.
- Found independently by two people on our side working from this asset, which is why it seemed worth sending up rather than just patching locally.
- No existing issue or PR covers it (searched `wrist_pitch_link`, `bodypair`).
