### PR TITLE
Fix undefined behaviour in the motion-tracking anchor observation

### DIFF
--- a/deploy/robots/g1/src/State_Mimic.cpp
+++ b/deploy/robots/g1/src/State_Mimic.cpp
@@ -3,7 +3,7 @@
 #include "isaaclab/envs/mdp/observations/observations.h"
 #include "isaaclab/envs/mdp/actions/joint_actions.h"
 
-static Eigen::Quaternionf init_quat;
+static Eigen::Quaternionf init_quat = Eigen::Quaternionf::Identity();
 std::shared_ptr<State_Mimic::MotionLoader_> State_Mimic::motion = nullptr;
 
 
@@ -68,8 +68,13 @@ REGISTER_OBSERVATION(motion_anchor_ori_b)
     auto real_quat_w = robot_quat_w(env);
     auto ref_quat_w  = motion_anchor_quat_w(loader);
 
-    auto rot_ = (init_quat * ref_quat_w).conjugate() * real_quat_w;
-    auto rot = rot_.toRotationMatrix().transpose();
+    const Eigen::Quaternionf rot_ = (init_quat * ref_quat_w).conjugate() * real_quat_w;
+    // NOT `auto`: toRotationMatrix() returns a temporary and .transpose() is a lazy
+    // expression that only holds a reference to it, so `auto rot = ...transpose()` keeps a
+    // reference to a destroyed temporary and the six values below are read from freed stack
+    // memory. It can look plausible (stale values that resemble a rotation) and then fail
+    // differently on another compiler or platform.
+    const Eigen::Matrix3f rot = rot_.toRotationMatrix().transpose();
 
     Eigen::Matrix<float, 6, 1> data;
     data << rot(0, 0), rot(0, 1), rot(1, 0), rot(1, 1), rot(2, 0), rot(2, 1);
@@ -147,6 +152,20 @@ void State_Mimic::enter()
     }
 
     motion = motion_; // set for specific motion
+
+    // Yaw-align the reference to the robot BEFORE env->reset(), because reset computes the
+    // observations and motion_anchor_ori_b reads init_quat. Doing it inside the policy
+    // thread (below) left the first observation built from a stale init_quat.
+    env->robot->update();
+    motion->reset(env->robot->data, time_range_[0]);
+    {
+        const Eigen::Matrix3f ref_yaw =
+            isaaclab::yawQuaternion(motion->root_quaternion()).toRotationMatrix();
+        const Eigen::Matrix3f robot_yaw =
+            isaaclab::yawQuaternion(robot_quat_w(env.get())).toRotationMatrix();
+        init_quat = Eigen::Quaternionf(robot_yaw * ref_yaw.transpose());
+    }
+
     env->reset();
     // Start policy thread
     policy_thread_running = true;
@@ -159,11 +178,7 @@ void State_Mimic::enter()
         const auto start = clock::now();
         auto sleepTill = start + dt;
 
-        motion->reset(env->robot->data, time_range_[0]);
-        auto ref_yaw = isaaclab::yawQuaternion(motion->root_quaternion()).toRotationMatrix();
-        auto robot_yaw = isaaclab::yawQuaternion(robot_quat_w(env.get())).toRotationMatrix();
-        init_quat = robot_yaw * ref_yaw.transpose();
-        env->reset();
+        env->reset();   // init_quat is set in enter(), before observations are built
 
         while (policy_thread_running)
         {


### PR DESCRIPTION
## Problem

`deploy/robots/g1/src/State_Mimic.cpp` builds the `motion_anchor_ori_b` observation from a dangling Eigen expression:

```cpp
auto rot_ = (init_quat * ref_quat_w).conjugate() * real_quat_w;
auto rot  = rot_.toRotationMatrix().transpose();
Eigen::Matrix<float, 6, 1> data;
data << rot(0,0), rot(0,1), rot(1,0), rot(1,1), rot(2,0), rot(2,1);
```

`toRotationMatrix()` returns a `Matrix3f` **by value**. `.transpose()` does not copy it — it returns a lazy `Transpose<>` expression holding a **reference** to that temporary. Because the result is bound with `auto`, the expression object outlives the temporary it points at: the temporary dies at the end of that statement, and every read on the next line dereferences dead stack.

This is the documented `auto` pitfall in Eigen's own guide ([C++11 and the auto keyword](https://eigen.tuxfamily.org/dox/TopicPitfalls.html)).

## It is not theoretical, and it is not visible on every build

Standalone repro — Eigen only, no SDK, no DDS, no robot. Save as `repro.cpp`:

```cpp
#include <Eigen/Dense>
#include <cstdio>
using Vec6 = Eigen::Matrix<float, 6, 1>;

__attribute__((noinline)) static float clobber() {
  volatile float s[64];
  for (int i = 0; i < 64; i++) s[i] = 3.14159f * (i + 1);
  float a = 0; for (int i = 0; i < 64; i++) a += s[i]; return a;
}
__attribute__((noinline)) static Vec6 buggy(const Eigen::Quaternionf& q) {
  auto rot = q.toRotationMatrix().transpose();          // dangling from here
  clobber();
  Vec6 d; d << rot(0,0), rot(0,1), rot(1,0), rot(1,1), rot(2,0), rot(2,1); return d;
}
__attribute__((noinline)) static Vec6 fixed_(const Eigen::Quaternionf& q) {
  const Eigen::Matrix3f rot = q.toRotationMatrix().transpose();   // materialised
  clobber();
  Vec6 d; d << rot(0,0), rot(0,1), rot(1,0), rot(1,1), rot(2,0), rot(2,1); return d;
}
int main() {
  const Eigen::Quaternionf q(Eigen::AngleAxisf(0.5236f, Eigen::Vector3f::UnitZ()));
  const Vec6 a = buggy(q), b = fixed_(q);
  std::printf("buggy: "); for (int i=0;i<6;i++) std::printf("%12.6f", a(i));
  std::printf("\nfixed: "); for (int i=0;i<6;i++) std::printf("%12.6f", b(i));
  std::printf("\n");
}
```

`g++ -std=c++17 -O0 -I/usr/include/eigen3 repro.cpp && ./a.out` — **looks fine**:

```
buggy:     0.866025    0.500001   -0.500001    0.866025    0.000000    0.000000
fixed:     0.866025    0.500001   -0.500001    0.866025    0.000000    0.000000
```

Same file, same compiler, `-O2`:

```
buggy:         -nan        -nan    0.000000    0.000000    0.000000    0.000000
fixed:     0.866025    0.500001   -0.500001    0.866025    0.000000    0.000000
```

And definitively, `g++ -O1 -g -fsanitize=address -fsanitize-address-use-after-scope`:

```
==ERROR: AddressSanitizer: stack-use-after-scope on address 0x... 
READ of size 4 at 0x... thread T0
    #0 Eigen::CommaInitializer<...>::CommaInitializer(...) Eigen/src/Core/CommaInitializer.h:38
    #1 Eigen::DenseBase<...>::operator<<(float const&)      Eigen/src/Core/CommaInitializer.h:150
    #2 buggy  repro.cpp:35
Address ... is located in stack of thread T0 at offset 368 in frame #0 buggy
  This frame has 10 object(s):
    [48, 56) 'rot' (line 32)
```

The read is inside the `data << ...` comma initializer — precisely the six observation values.

That `-O0` output is the important one: it is why this survived review. On the build where it "works", it works.

## What we saw downstream

On our platform the stale read returned values belonging to nearby objects — the motion clip's own duration fields (26.240 and 13.120) appeared as "rotation" entries — and the policy then emitted actions on the order of 1e19.

## Fix

Materialise into a concrete type, and give `rot_` an explicit type too so it cannot become an expression:

```cpp
const Eigen::Quaternionf rot_ = (init_quat * ref_quat_w).conjugate() * real_quat_w;
const Eigen::Matrix3f    rot  = rot_.toRotationMatrix().transpose();
```

The maths is unchanged.

## Second, smaller problem in the same path

`static Eigen::Quaternionf init_quat;` was default-constructed — Eigen does not zero-initialise — and only assigned inside the policy thread. But `enter()` calls `env->reset()` before that, and `reset()` computes the observations, which read `init_quat`. So the first observation was built from an uninitialised quaternion.

This patch identity-initialises it and moves the yaw alignment into `enter()` ahead of `reset()`, so the value is valid before anything reads it.

## Notes

- One file. Types and ordering only, no behaviour change to the maths.
- We could not build the full deploy stack to test end to end — it needs `ddscxx`, which on our side exists only on the robot's Orin. The repro above needs none of that, and the sanitizer output is from a clean run of it.
