### PR TITLE
fix: add upper bounds for mujoco and warp-lang, declare scipy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,20 @@ from setuptools import setup, find_packages
 INSTALL_REQUIRES = [
     "mjlab==1.2.0",
     "mujoco-warp==3.5.0",
+    # mujoco-warp 3.5.0 is built against the matching mujoco 3.5.x C API. mjlab
+    # only requires "mujoco>=3.5.0", so a fresh resolve pulls the newest mujoco
+    # (3.11.0), where mjtEnableBit.mjENBL_MULTICCD no longer exists and
+    # `import mujoco_warp` fails outright. Pin the pair together.
+    "mujoco==3.5.0",
+    # Same story for warp. mjlab 1.2.0 calls `wp.context.runtime` (sim/sim.py)
+    # and `wp.context.Device` (sensor/raycast_sensor.py), but declares only
+    # "warp-lang>=1.12.0". warp moved that namespace to `warp._src.context`, so
+    # any resolve picking up >=1.13 fails with
+    # "module 'warp' has no attribute 'context'" the moment an env is built.
+    "warp-lang==1.12.0",
+    # mjlab's terrain module imports scipy (terrains/heightfield_terrains.py)
+    # but never declares it, so a clean install cannot construct any terrain.
+    "scipy",
 ]
 
 # Installation operation


### PR DESCRIPTION
A clean install of this repo currently fails. All three dependencies below are declared by `mjlab 1.2.0` with a lower bound and no upper bound, and the ecosystem has moved past each of them.

### `mujoco`

`mujoco-warp 3.5.0` is built against the matching `mujoco` 3.5.x C API, but mjlab requires only `mujoco>=3.5.0`. A fresh resolve installs `mujoco 3.11.0`, where `mjtEnableBit.mjENBL_MULTICCD` no longer exists, and `import mujoco_warp` fails outright.

### `warp-lang`

mjlab 1.2.0 calls `wp.context.runtime` (`sim/sim.py`) and `wp.context.Device` (`sensor/raycast_sensor.py`) while declaring only `warp-lang>=1.12.0`. warp moved that namespace to `warp._src.context` in 1.13, so any resolve picking up `>=1.13` raises:

```
module 'warp' has no attribute 'context'
```

This one is worth highlighting because it is **not** caught at import time — it only surfaces when an environment is actually constructed, so it looks like a task bug rather than a dependency problem.

### `scipy`

mjlab's `terrains/heightfield_terrains.py` imports scipy but never declares it, so a clean install cannot construct any terrain.

---

## Change

Pin `mujoco` and `warp-lang` to the versions `mujoco-warp 3.5.0` and `mjlab 1.2.0` were built against, and declare `scipy` explicitly. Inline comments explain each pin so a future bump doesn't silently reintroduce the same break.

## Verification

Ubuntu 24.04 (WSL2), Python 3.11.15, RTX 3060, driver 576.52 / CUDA 12.9. After this change: `import mujoco_warp` succeeds, environments build, and G1 velocity training runs on GPU. Before it, a fresh `pip install -e .` in a clean venv reproduces all three failures.

## Note on scope

This is only the dependency fix. Happy to narrow the pins to compatible ranges (e.g. `mujoco>=3.5,<3.6`) instead of exact pins if you'd prefer — exact pins were the conservative choice since `mujoco-warp` tracks the `mujoco` C API closely.
